### PR TITLE
Improve vimrc

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,9 +1,4 @@
-# [user]
-# 	name = Luo Xin
-# 	email = luoxin.net@gmail.com
-# 	email = xluo@freewheel.tv
 [core]
-# 	editor = /usr/local/bin/vim
 	editor = vim
 	excludesfile = ~/.gitignore
 [alias]
@@ -18,3 +13,5 @@
 	lg = !"git lg1"
 [push]
 	default = simple
+[include]
+  path = ~/.gitconfig.user

--- a/vimrc
+++ b/vimrc
@@ -71,6 +71,7 @@ set termencoding=utf-8
 set tags=./tags;$HOME
 set nobackup
 set noswapfile
+set exrc
 
 if exists('+colorcolumn')
   set colorcolumn=80
@@ -148,7 +149,10 @@ let g:vimshell_editor_command='/usr/local/bin/vim'
 " unite
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:unite_source_history_yank_enable = 1
+let g:unite_matcher_fuzzy_max_input_length = 30
+let g:unite_source_rec_max_cache_files = 30000
 call unite#filters#matcher_default#use(['matcher_fuzzy'])
+call unite#filters#sorter_default#use(['sorter_selecta'])
 nnoremap <C-p>     :<C-u>Unite -start-insert file_rec/async:!<CR>
 nnoremap <leader>f :<C-u>Unite -start-insert file_rec/async:!<CR>
 nnoremap <Leader>s :<C-u>Unite -auto-preview grep:.<CR>
@@ -164,11 +168,13 @@ endfunction
 if executable('ag')
   let g:unite_source_grep_command = 'ag'
   let g:unite_source_grep_default_opts =
-        \ '-i --line-numbers --nocolor --nogroup --hidden --ignore ' .
-        \  '''.hg'' --ignore ''.svn'' --ignore ''.git'' --ignore ''.bzr'''
+        \ '-i --line-numbers --nocolor --nogroup --hidden ' .
+        \ '--ignore ''.hg'' --ignore ''.svn'' ' .
+        \ '--ignore ''.git'' --ignore ''.bzr'''
   let g:unite_source_grep_recursive_opt = ''
   let g:unite_source_rec_async_command =
-        \ 'ag --follow --nocolor --nogroup --hidden -g ""'
+        \ 'ag --follow --nocolor --nogroup ' .
+        \ '-g ""'
 endif
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
- tune .gitconfig
  - load git user email config from ~/.gitconfig.user
- tune vimrc: …
  - load project specifc .vimrc
  - use sorter_selecta as default sorter, which offers much better result
  - enlarge matcher_fuzzy max input length to 30
  - do not search upon hidden files for file_rec/async, this can
    potentially lower down results to the half
